### PR TITLE
Potential fix for code scanning alert no. 4: Semicolon insertion

### DIFF
--- a/src/archive/testrail_suites.ts
+++ b/src/archive/testrail_suites.ts
@@ -204,7 +204,7 @@ export function addTestRailSuiteTools(server: FastMCP) {
       const { suite_id, soft } = args;
       let url = `${env.TESTRAIL_URL}/index.php?/api/v2/delete_suite/${suite_id}`;
       if(soft) {
-        url += `&soft=${soft}`
+        url += `&soft=${soft}`;
       }
       const authHeader = `Basic ${Buffer.from(
         `${env.TESTRAIL_USER}:${env.TESTRAIL_API_KEY}`


### PR DESCRIPTION
Potential fix for [https://github.com/CatScan-crypt/testrail_mcp/security/code-scanning/4](https://github.com/CatScan-crypt/testrail_mcp/security/code-scanning/4)

To fix the problem, add an explicit semicolon to the end of the statement `url += `&soft=${soft}`` on line 207 in src/archive/testrail_suites.ts. This change is minimal, aligns with the file's coding style, and removes reliance on JavaScript's automatic semicolon insertion. No other changes, imports, or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
